### PR TITLE
biovol for all but small

### DIFF
--- a/src/services/preprocessing/BiovolAndSurfaceAreaCalculator/service.py
+++ b/src/services/preprocessing/BiovolAndSurfaceAreaCalculator/service.py
@@ -54,7 +54,7 @@ class BiovolAndSurfaceAreaCalculator:
 def bcal_function(lc_data: LabelCheckerData, data_directory, config: Config) -> LabelCheckerData:
 
     preprocessing = lc_data.get_value("Preprocessing")
-    if preprocessing != 'object':
+    if preprocessing == 'small':
         return lc_data
 
     CollageFile_name = lc_data.get_value("CollageFile")


### PR DESCRIPTION
Currently biovolume is calculated for only 'object' (I requested that). But the problem is when duplicate/bubble detection is activated - we have a lot false positives for these and they don't have biovolume.